### PR TITLE
EL 9 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ These are the minimum variables needed to create a cluster with a user and datab
 | `xtradb_version` | `80` | Package version of XtraDB |
 | `xtradb_ssl_client_only` | `false` | Disallow non-SSL client connections |
 | `xtradb_tls_enabled` | `true` | Enable TLS encryption for cluster traffic |
-| `xtradb_configure_firewalld` | `false` | Allow xtradb ports through firewalld for EL 7/8 based distros |
+| `xtradb_configure_firewalld` | `false` | Allow xtradb ports through firewalld for EL 7/8/9 based distros |
 
 ### MySQL part
 For more info on the values, read the [MariaDB Server System Variables documentation](https://mariadb.com/kb/en/mariadb/server-system-variables/).

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -65,19 +65,48 @@
     state: present
   when: xtradb_configure_firewalld
 
-- name: EL | Set firewalld ports
+- name: EL | Set firewalld mySQL port 3306
   ansible.posix.firewalld:
-    port: "{{ fwport }}/tcp"
+    port: "3306/tcp"
     permanent: true
     state: enabled
     immediate: true
-  with_items:
-    - 3306
-    - 4444
-    - 4567
-    - 4568
+  when: xtradb_configure_firewalld
+
+- name: EL | Set firewalld cluster port 4444
+  ansible.posix.firewalld:
+    port: "4444/tcp"
+    source: "{{ fwsource.ansible_default_ipv4.address }}/32"
+    permanent: true
+    state: enabled
+    immediate: true
+  with_items: "{{ hostvars[groups['db']] }}"
   when: xtradb_configure_firewalld
   loop_control:
-    loop_var: fwport
+    loop_var: fwsource
+
+- name: EL | Set firewalld cluster port 4567
+  ansible.posix.firewalld:
+    port: "4567/tcp"
+    source: "{{ fwsource.ansible_default_ipv4.address }}/32"
+    permanent: true
+    state: enabled
+    immediate: true
+  with_items: "{{ hostvars[groups['db']] }}"
+  when: xtradb_configure_firewalld
+  loop_control:
+    loop_var: fwsource
+
+- name: EL | Set firewalld cluster port 4568
+  ansible.posix.firewalld:
+    port: "4568/tcp"
+    source: "{{ fwsource.ansible_default_ipv4.address }}/32"
+    permanent: true
+    state: enabled
+    immediate: true
+  with_items: "{{ hostvars[groups['db']] }}"
+  when: xtradb_configure_firewalld
+  loop_control:
+    loop_var: fwsource
 
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,9 +1,5 @@
 # tasks for Red Hat Familly
 ---
-- name: Print the gateway for each host when defined
-  ansible.builtin.debug:
-    msg: distribution_major_version == {{ ansible_facts['distribution_major_version'] }}
-
 - name: Bound IP Addresses
   ansible.builtin.debug:
     var: xtradb_bind_address

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,5 +1,9 @@
 # tasks for Red Hat Familly
 ---
+- name: Print the gateway for each host when defined
+  ansible.builtin.debug:
+    msg: distribution_major_version == {{ ansible_facts['distribution_major_version'] }}
+
 - name: Bound IP Addresses
   ansible.builtin.debug:
     var: xtradb_bind_address
@@ -38,7 +42,8 @@
   ansible.builtin.package:
     name: python3-PyMySQL
     state: present
-  when: (ansible_facts['distribution_major_version'] == "8") or (ansible_facts['distribution_major_version'] == "9")
+  when: (ansible_facts['distribution_major_version'] == "8") or
+        (ansible_facts['distribution_major_version'] == "9")
 
 - name: EL7 | Set Python firewalld module package name
   ansible.builtin.set_fact:
@@ -48,13 +53,15 @@
 - name: EL8/9 | Set Python firewalld module package name
   ansible.builtin.set_fact:
     python_firewalld_module_package: python3-firewall
-  when: (ansible_facts['distribution_major_version'] == "8") or (ansible_facts['distribution_major_version'] == "9")
+  when: (ansible_facts['distribution_major_version'] == "8") or
+        (ansible_facts['distribution_major_version'] == "9")
 
 - name: EL8/9 | Install diffutils
   ansible.builtin.package:
     name: diffutils
     state: present
-  when: (ansible_facts['distribution_major_version'] == "8") or (ansible_facts['distribution_major_version'] == "9")
+  when: (ansible_facts['distribution_major_version'] == "8") or
+        (ansible_facts['distribution_major_version'] == "9")
 
 - name: EL | Install firewalld python module
   ansible.builtin.package:

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -65,48 +65,25 @@
     state: present
   when: xtradb_configure_firewalld
 
-- name: EL | Set firewalld mySQL port 3306
-  ansible.posix.firewalld:
-    port: "3306/tcp"
-    permanent: true
-    state: enabled
-    immediate: true
+- name: EL | Install firewalld python module
+  ansible.builtin.package:
+    name: "{{ python_firewalld_module_package }}"
+    state: present
   when: xtradb_configure_firewalld
 
-- name: EL | Set firewalld cluster port 4444
+- name: EL | Set firewalld ports
   ansible.posix.firewalld:
-    port: "4444/tcp"
-    source: "{{ fwsource.ansible_default_ipv4.address }}/32"
+    port: "{{ fwport }}/tcp"
     permanent: true
     state: enabled
     immediate: true
-  with_items: "{{ hostvars[groups['db']] }}"
+  with_items:
+    - 3306
+    - 4444
+    - 4567
+    - 4568
   when: xtradb_configure_firewalld
   loop_control:
-    loop_var: fwsource
-
-- name: EL | Set firewalld cluster port 4567
-  ansible.posix.firewalld:
-    port: "4567/tcp"
-    source: "{{ fwsource.ansible_default_ipv4.address }}/32"
-    permanent: true
-    state: enabled
-    immediate: true
-  with_items: "{{ hostvars[groups['db']] }}"
-  when: xtradb_configure_firewalld
-  loop_control:
-    loop_var: fwsource
-
-- name: EL | Set firewalld cluster port 4568
-  ansible.posix.firewalld:
-    port: "4568/tcp"
-    source: "{{ fwsource.ansible_default_ipv4.address }}/32"
-    permanent: true
-    state: enabled
-    immediate: true
-  with_items: "{{ hostvars[groups['db']] }}"
-  when: xtradb_configure_firewalld
-  loop_control:
-    loop_var: fwsource
+    loop_var: fwport
 
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -34,27 +34,27 @@
     state: present
   when: ansible_facts['distribution_major_version'] == "7"
 
-- name: EL8 | Install MySQL Python connector
+- name: EL8/9 | Install MySQL Python connector
   ansible.builtin.package:
     name: python3-PyMySQL
     state: present
-  when: ansible_facts['distribution_major_version'] == "8"
+  when: (ansible_facts['distribution_major_version'] == "8") or (ansible_facts['distribution_major_version'] == "9")
 
 - name: EL7 | Set Python firewalld module package name
   ansible.builtin.set_fact:
     python_firewalld_module_package: python-firewall
   when: ansible_facts['distribution_major_version'] == "7"
 
-- name: EL8 | Set Python firewalld module package name
+- name: EL8/9 | Set Python firewalld module package name
   ansible.builtin.set_fact:
     python_firewalld_module_package: python3-firewall
-  when: ansible_facts['distribution_major_version'] == "8"
+  when: (ansible_facts['distribution_major_version'] == "8") or (ansible_facts['distribution_major_version'] == "9")
 
-- name: EL8 | Install diffutils
+- name: EL8/9 | Install diffutils
   ansible.builtin.package:
     name: diffutils
     state: present
-  when: ansible_facts['distribution_major_version'] == "8"
+  when: (ansible_facts['distribution_major_version'] == "8") or (ansible_facts['distribution_major_version'] == "9")
 
 - name: EL | Install firewalld python module
   ansible.builtin.package:


### PR DESCRIPTION
Note that EL 9 is not currently supported by Percona (same with Ubuntu 22.04):
https://www.percona.com/services/policies/percona-software-support-lifecycle

RHEL 9 should probably not be installed on until it is supported but this will make the playbook work properly for the mySQL module and firewall.